### PR TITLE
Add example controller

### DIFF
--- a/explore_coderabbit.routing.yml
+++ b/explore_coderabbit.routing.yml
@@ -1,0 +1,7 @@
+explore_coderabbit.example:
+  path: '/explore-coderabbit/example'
+  defaults:
+    _title: 'Example'
+    _controller: '\Drupal\explore_coderabbit\Controller\ExploreCoderabbitController'
+  requirements:
+    _permission: 'Yes'

--- a/src/Controller/ExploreCoderabbitController.php
+++ b/src/Controller/ExploreCoderabbitController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\explore_coderabbit\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Returns responses for Explore CodeRabbit routes.
+ */
+final class ExploreCoderabbitController extends ControllerBase {
+
+  /**
+   * Builds the response.
+   */
+  public function __invoke(): array {
+
+    $build['content'] = [
+      '#type' => 'item',
+      '#markup' => $this->t('It works!'),
+    ];
+
+    return $build;
+  }
+
+}


### PR DESCRIPTION
Adding a example controller for checking code rabbit workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new routing configuration for the `explore_coderabbit` module, allowing users to access the path `/explore-coderabbit/example`.
	- Added a controller that provides a response indicating the functionality is operational when the route is accessed.
- **Permissions**
	- Implemented permission requirements for accessing the new route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->